### PR TITLE
Update libmicrohttpd version in Windows 2019 compile workflow

### DIFF
--- a/.github/workflows/win-2019-compile.yml
+++ b/.github/workflows/win-2019-compile.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install pre-compiled libmicrohttpd Win64
         run: |
-          curl  -Lo libmicrohttpd-latest-w32-bin.zip https://ftpmirror.gnu.org/libmicrohttpd/libmicrohttpd-latest-w32-bin.zip
+          curl  -Lo libmicrohttpd-latest-w32-bin.zip https://ftpmirror.gnu.org/libmicrohttpd/libmicrohttpd-0.9.75-w32-bin.zip
           unzip libmicrohttpd-latest-w32-bin.zip
 
       - name: Compile


### PR DESCRIPTION
This PR addresses an issue in our GitHub Actions script related to the libmicrohttpd version. 

Previously, our script was downloading the latest version of libmicrohttpd with this command:

```
curl -Lo libmicrohttpd-latest-w32-bin.zip https://ftpmirror.gnu.org/libmicrohttpd/libmicrohttpd-latest-w32-bin.zip
```

However, our script's libmicrohttpd library path is specifically defined for version 0.9.75:
```
-DMHD_LIBRARY=%root%\libmicrohttpd-0.9.75-w32-bin\x86_64\VS2019\Release-static\libmicrohttpd.lib
```

Since the latest version is 0.9.77, it causes inconsistencies when trying to locate the library, causing the process to fail. 

To fix this issue, I've changed the curl command to download specifically the 0.9.75 version:

```
curl -Lo libmicrohttpd-latest-w32-bin.zip https://ftpmirror.gnu.org/libmicrohttpd/libmicrohttpd-0.9.75-w32-bin.zip
```

This way, we can ensure the specified library path in our GitHub Actions script matches the version we're actually downloading and using, eliminating the error. 

Please review and let me know if there are any concerns.

Dr.Awesome Doge