### PR TITLE
Add quick Ubuntu build guide

### DIFF
--- a/docs/BUILD_UBUNTU.md
+++ b/docs/BUILD_UBUNTU.md
@@ -1,0 +1,13 @@
+# Build Guide for Ubuntu
+
+## Requirements
+bash
+Skopiuj kod
+sudo apt-get update
+sudo apt-get install -y build-essential git cmake ninja-build zlib1g-dev libsodium-dev
+Build
+bash
+Skopiuj kod
+cp assembly/native/build-ubuntu-shared.sh .
+chmod +x build-ubuntu-shared.sh
+./build-ubuntu-shared.sh


### PR DESCRIPTION
This PR adds a new markdown file BUILD_UBUNTU.md under /docs with a short and clear guide for building the TON project on Ubuntu using provided scripts.
Closes #1