### PR TITLE
After the build completes, binaries are available in the build/ directory.

### DIFF
--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,0 +1,10 @@
+# TON Quick Start Guide
+
+To build TON on Ubuntu 22.04:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential git cmake ninja-build libsodium-dev
+cp assembly/native/build-ubuntu-shared.sh .
+chmod +x build-ubuntu-shared.sh
+./build-ubuntu-shared.sh


### PR DESCRIPTION

### 🚀 **Pull Request**
**Title:** Add quick start build guide for Ubuntu  

**Description:**  
This PR adds a new documentation file `docs/QUICK_START.md` containing short and clear instructions to build the TON project on Ubuntu systems.  

The guide simplifies onboarding for new contributors and helps reduce setup time.  
No code changes — documentation only.  

**Type:** Documentation update  
**Branch:** `feature/add-quick-start-guide` → `master`  

