### PR TITLE
Add example for running TON Lite Client on Testnet

### DIFF
--- a/example/run-lite-client-testnet.sh
+++ b/example/run-lite-client-testnet.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Example: Run TON Lite Client connected to Testnet
+# Description:
+#   This script shows how to connect to TON testnet using lite-client.
+#   It automatically downloads global config and starts the client.
+
+set -e
+
+CONFIG_URL="https://ton-blockchain.github.io/testnet-global.config.json"
+CONFIG_FILE="testnet-global.config.json"
+
+echo "[INFO] Downloading TON Testnet config..."
+curl -s -o "$CONFIG_FILE" "$CONFIG_URL"
+
+echo "[INFO] Starting TON Lite Client..."
+./lite-client/lite-client \
+  -C "$CONFIG_FILE" \
+  -v 2 \
+  -p 1
+
+# Example usage inside client:
+# > getaccount <account_address>
+# > last
+# > quit


### PR DESCRIPTION
### What
Introduces a new example script `run-lite-client-testnet.sh`
to simplify connecting to TON Testnet with the lite-client binary.

### Why
Currently, developers must manually locate and download the global config file
and remember startup flags. This script automates that process.

### Details
- Added script under `/example/`
- Automatically fetches `testnet-global.config.json`
- Runs `lite-client` with testnet parameters and basic verbosity
- Includes usage examples in comments

### Tested
✅ Ubuntu 22.04 (x86-64)
✅ lite-client built via `build-ubuntu-shared.sh`

### Result
Users can now run:
```bash
bash example/run-lite-client-testnet.sh
